### PR TITLE
Update to num-complex v0.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ keywords = ["linear-algebra"]
 libc = "0.2"
 
 [dependencies.num-complex]
-version = "0.1"
+version = "0.2"
 default-features = false
 
 [dependencies.lapack-sys]


### PR DESCRIPTION
This updates the num-complex dependency. No modifications other than the version number were necessary.